### PR TITLE
Two new rounding modes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ dist
 .tern-port
 
 node_modules
+coverage

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ divide(DIRECTED_AWAY_FROM_ZERO, 25n, 10n) // 3n
 
 This object contains the following enumerated values. More detailed information about these modes of integer rounding can be found [on Wikipedia](https://en.wikipedia.org/wiki/Rounding#Rounding_to_integer).
 
+#### THROW
+
+If `b` does not divide `a`, instead of attempting rounding, throw an exception.
+
 #### DIRECTED_TOWARDS_ZERO
 
 Always round fractions "down", towards zero. Note that this is the default rounding mode in JavaScript `BigInt` division. `big-round` provides it for completeness, but you can do `a / b` to get an identical result.
@@ -37,6 +41,10 @@ Always round fractions towards positive infinity. Equivalent to applying the cei
 #### STOCHASTIC
 
 Round all fractions up or down randomly with probability proportional to proximity. *E.g.* a quotient of 1.7 is rounded down to `1n` with probability .3 and up to `2n` with probability .7.
+
+#### NEAREST_HALF_THROW
+
+Round fractions to the nearest integer. If the fraction is exactly .5, instead of attempting rounding, throw an exception.
 
 #### NEAREST_HALF_TOWARDS_ZERO
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   // automock: false,
 
   // Stop running tests after `n` failures
-  // bail: 0,
+  bail: false,
 
   // The directory where Jest should store its cached dependency information
   // cacheDirectory: "C:\\Users\\qntm\\AppData\\Local\\Temp\\jest",
@@ -15,10 +15,13 @@ module.exports = {
   // clearMocks: false,
 
   // Indicates whether the coverage information should be collected while executing the test
-  // collectCoverage: false,
+  collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  // collectCoverageFrom: undefined,
+  collectCoverageFrom: [
+    'src/*.js',
+    '!src/*.spec.js'
+  ],
 
   // The directory where Jest should output its coverage files
   // coverageDirectory: undefined,
@@ -37,7 +40,14 @@ module.exports = {
   // ],
 
   // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100
+    }
+  },
 
   // A path to a custom dependency extractor
   // dependencyExtractor: undefined,
@@ -129,7 +139,7 @@ module.exports = {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-  testEnvironment: "node",
+  testEnvironment: 'node',
 
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {},
@@ -175,11 +185,11 @@ module.exports = {
   // unmockedModulePathPatterns: undefined,
 
   // Indicates whether each individual test should be reported during the run
-  // verbose: undefined,
+  verbose: true
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
   // watchPathIgnorePatterns: [],
 
   // Whether to use watchman for file crawling
   // watchman: true,
-};
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "big-round",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Custom rounding behaviour for BigInt arithmetic",
   "homepage": "https://github.com/qntm/big-round",
   "repository": {
@@ -10,9 +10,11 @@
   "main": "src/index.js",
   "dependencies": {},
   "devDependencies": {
-    "jest": "^26.0.1"
+    "jest": "^26.0.1",
+    "standard": "^16.0.3"
   },
   "scripts": {
+    "pretest": "standard",
     "test": "jest"
   },
   "author": "qntm",

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 const ROUNDING_MODE = {
+  THROW: -1,
   DIRECTED_TOWARDS_ZERO: 0,
   DIRECTED_AWAY_FROM_ZERO: 1,
   DIRECTED_TOWARDS_NEGATIVE_INFINITY: 2,
   DIRECTED_TOWARDS_POSITIVE_INFINITY: 3,
   STOCHASTIC: 4,
+  NEAREST_HALF_THROW: 4.5,
   NEAREST_HALF_TOWARDS_ZERO: 5,
   NEAREST_HALF_AWAY_FROM_ZERO: 6,
   NEAREST_HALF_TOWARDS_NEGATIVE_INFINITY: 7,
@@ -28,6 +30,10 @@ const randBigInt = range =>
 let alternateUp = false
 
 const divide = (roundingMode, a, b) => {
+  if (!Object.values(ROUNDING_MODE).some(r => r === roundingMode)) {
+    throw Error('Unrecognised rounding strategy')
+  }
+
   const q = a / b
 
   // `b` must be non-zero or we would have thrown an exception by now
@@ -36,9 +42,11 @@ const divide = (roundingMode, a, b) => {
   // We may need to undo this, by adding back 1n, or -1n if `r` was negative.
 
   // What was the sign of `r`? May be non-zero even if `q` is `0n` e.g. 1n / 10n
-  const sign = a === 0n ? 0n
-    : a > 0n === b > 0n ? 1n
-    : -1n
+  const sign = a === 0n
+    ? 0n
+    : (a > 0n) === (b > 0n)
+        ? 1n
+        : -1n
 
   // What fraction was truncated to make `r` into `q`?
   const absA = a >= 0n ? a : -a
@@ -46,31 +54,47 @@ const divide = (roundingMode, a, b) => {
 
   const remainder = absA % absB
 
-  const undoTruncation = remainder === 0n ? false // no truncation occurred
-    : roundingMode === ROUNDING_MODE.DIRECTED_TOWARDS_ZERO ? false
-    : roundingMode === ROUNDING_MODE.DIRECTED_AWAY_FROM_ZERO ? true
-    : roundingMode === ROUNDING_MODE.DIRECTED_TOWARDS_NEGATIVE_INFINITY ? sign < 0n
-    : roundingMode === ROUNDING_MODE.DIRECTED_TOWARDS_POSITIVE_INFINITY ? sign > 0n
-    : roundingMode === ROUNDING_MODE.STOCHASTIC ? randBigInt(absB) < remainder
+  const undoTruncation = remainder === 0n
+    ? false // no truncation occurred
+    : roundingMode === ROUNDING_MODE.THROW
+      ? (() => { throw Error('b does not divide a') })()
+      : roundingMode === ROUNDING_MODE.DIRECTED_TOWARDS_ZERO
+        ? false
+        : roundingMode === ROUNDING_MODE.DIRECTED_AWAY_FROM_ZERO
+          ? true
+          : roundingMode === ROUNDING_MODE.DIRECTED_TOWARDS_NEGATIVE_INFINITY
+            ? sign < 0n
+            : roundingMode === ROUNDING_MODE.DIRECTED_TOWARDS_POSITIVE_INFINITY
+              ? sign > 0n
+              : roundingMode === ROUNDING_MODE.STOCHASTIC
+                ? randBigInt(absB) < remainder
 
-    // All modes beyond this point round to nearest
-    : remainder * 2n < absB ? false // truncated less than .5, leave it
-    : remainder * 2n > absB ? true // truncated more than .5, undo that
+                // All modes beyond this point round to nearest
+                : remainder * 2n < absB
+                  ? false // truncated less than .5, leave it
+                  : remainder * 2n > absB
+                    ? true // truncated more than .5, undo that
 
-    // Truncated .5 exactly, decide tie break
-    : roundingMode === ROUNDING_MODE.NEAREST_HALF_TOWARDS_ZERO ? false
-    : roundingMode === ROUNDING_MODE.NEAREST_HALF_AWAY_FROM_ZERO ? true
-    : roundingMode === ROUNDING_MODE.NEAREST_HALF_TOWARDS_NEGATIVE_INFINITY ? sign < 0n
-    : roundingMode === ROUNDING_MODE.NEAREST_HALF_TOWARDS_POSITIVE_INFINITY ? sign > 0n
-    : roundingMode === ROUNDING_MODE.NEAREST_HALF_TO_EVEN ? q % 2n !== 0n
-    : roundingMode === ROUNDING_MODE.NEAREST_HALF_TO_ODD ? q % 2n === 0n
-    : roundingMode === ROUNDING_MODE.NEAREST_HALF_ALTERNATE ? (alternateUp = !alternateUp)
-    : roundingMode === ROUNDING_MODE.NEAREST_HALF_RANDOM ? Math.random() < .5
-    : undefined
+                    // Truncated .5 exactly, decide tie break
+                    : roundingMode === ROUNDING_MODE.NEAREST_HALF_THROW
+                      ? (() => { throw Error('cannot round a fraction of .5') })()
+                      : roundingMode === ROUNDING_MODE.NEAREST_HALF_TOWARDS_ZERO
+                        ? false
+                        : roundingMode === ROUNDING_MODE.NEAREST_HALF_AWAY_FROM_ZERO
+                          ? true
+                          : roundingMode === ROUNDING_MODE.NEAREST_HALF_TOWARDS_NEGATIVE_INFINITY
+                            ? sign < 0n
+                            : roundingMode === ROUNDING_MODE.NEAREST_HALF_TOWARDS_POSITIVE_INFINITY
+                              ? sign > 0n
+                              : roundingMode === ROUNDING_MODE.NEAREST_HALF_TO_EVEN
+                                ? q % 2n !== 0n
+                                : roundingMode === ROUNDING_MODE.NEAREST_HALF_TO_ODD
+                                  ? q % 2n === 0n
+                                  : roundingMode === ROUNDING_MODE.NEAREST_HALF_ALTERNATE
+                                    ? (alternateUp = !alternateUp)
 
-  if (undoTruncation === undefined) {
-    throw Error('Unrecognised rounding strategy')
-  }
+                                    // ROUNDING_MODE.NEAREST_HALF_RANDOM
+                                    : Math.random() < 0.5
 
   return q + (undoTruncation ? sign : 0n)
 }

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 // Test data mostly from Wikipedia
 // <https://en.wikipedia.org/w/index.php?title=Rounding&oldid=960109264#Comparison_of_approaches_for_rounding_to_an_integer>
 
@@ -7,7 +9,83 @@ const {
 } = require('.')
 
 describe('divide', () => {
+  describe('unrecognised', () => {
+    it('throws', () => {
+      expect(() => divide(-50103, 18n, 10n)).toThrowError()
+      expect(() => divide(-50103, 15n, 10n)).toThrowError()
+      expect(() => divide(-50103, 12n, 10n)).toThrowError()
+      expect(() => divide(-50103, 10n, 10n)).toThrowError()
+      expect(() => divide(-50103, 8n, 10n)).toThrowError()
+      expect(() => divide(-50103, 5n, 10n)).toThrowError()
+      expect(() => divide(-50103, 2n, 10n)).toThrowError()
+      expect(() => divide(-50103, 0n, 10n)).toThrowError()
+      expect(() => divide(-50103, -2n, 10n)).toThrowError()
+      expect(() => divide(-50103, -5n, 10n)).toThrowError()
+      expect(() => divide(-50103, -8n, 10n)).toThrowError()
+      expect(() => divide(-50103, -10n, 10n)).toThrowError()
+      expect(() => divide(-50103, -12n, 10n)).toThrowError()
+      expect(() => divide(-50103, -15n, 10n)).toThrowError()
+      expect(() => divide(-50103, -18n, 10n)).toThrowError()
+    })
+
+    it('throws on negatives', () => {
+      expect(() => divide(-50103, -18n, -10n)).toThrowError()
+      expect(() => divide(-50103, -15n, -10n)).toThrowError()
+      expect(() => divide(-50103, -12n, -10n)).toThrowError()
+      expect(() => divide(-50103, -10n, -10n)).toThrowError()
+      expect(() => divide(-50103, -8n, -10n)).toThrowError()
+      expect(() => divide(-50103, -5n, -10n)).toThrowError()
+      expect(() => divide(-50103, -2n, -10n)).toThrowError()
+      expect(() => divide(-50103, 0n, -10n)).toThrowError()
+      expect(() => divide(-50103, 2n, -10n)).toThrowError()
+      expect(() => divide(-50103, 5n, -10n)).toThrowError()
+      expect(() => divide(-50103, 8n, -10n)).toThrowError()
+      expect(() => divide(-50103, 10n, -10n)).toThrowError()
+      expect(() => divide(-50103, 12n, -10n)).toThrowError()
+      expect(() => divide(-50103, 15n, -10n)).toThrowError()
+      expect(() => divide(-50103, 18n, -10n)).toThrowError()
+    })
+  })
+
   describe('directed', () => {
+    describe('throw', () => {
+      it('works', () => {
+        expect(() => divide(ROUNDING_MODE.THROW, 18n, 10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, 15n, 10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, 12n, 10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.THROW, 10n, 10n)).toBe(1n)
+        expect(() => divide(ROUNDING_MODE.THROW, 8n, 10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, 5n, 10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, 2n, 10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.THROW, 0n, 10n)).toBe(0n)
+        expect(() => divide(ROUNDING_MODE.THROW, -2n, 10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, -5n, 10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, -8n, 10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.THROW, -10n, 10n)).toBe(-1n)
+        expect(() => divide(ROUNDING_MODE.THROW, -12n, 10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, -15n, 10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, -18n, 10n)).toThrowError()
+      })
+
+      it('works on negatives', () => {
+        expect(() => divide(ROUNDING_MODE.THROW, -18n, -10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, -15n, -10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, -12n, -10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.THROW, -10n, -10n)).toBe(1n)
+        expect(() => divide(ROUNDING_MODE.THROW, -8n, -10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, -5n, -10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, -2n, -10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.THROW, 0n, -10n)).toBe(0n)
+        expect(() => divide(ROUNDING_MODE.THROW, 2n, -10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, 5n, -10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, 8n, -10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.THROW, 10n, -10n)).toBe(-1n)
+        expect(() => divide(ROUNDING_MODE.THROW, 12n, -10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, 15n, -10n)).toThrowError()
+        expect(() => divide(ROUNDING_MODE.THROW, 18n, -10n)).toThrowError()
+      })
+    })
+
     describe('towards zero', () => {
       it('works', () => {
         expect(divide(ROUNDING_MODE.DIRECTED_TOWARDS_ZERO, 18n, 10n)).toBe(1n)
@@ -162,6 +240,44 @@ describe('divide', () => {
   })
 
   describe('to nearest', () => {
+    describe('half throws', () => {
+      it('works', () => {
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 18n, 10n)).toBe(2n)
+        expect(() => divide(ROUNDING_MODE.NEAREST_HALF_THROW, 15n, 10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 12n, 10n)).toBe(1n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 10n, 10n)).toBe(1n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 8n, 10n)).toBe(1n)
+        expect(() => divide(ROUNDING_MODE.NEAREST_HALF_THROW, 5n, 10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 2n, 10n)).toBe(0n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 0n, 10n)).toBe(0n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, -2n, 10n)).toBe(0n)
+        expect(() => divide(ROUNDING_MODE.NEAREST_HALF_THROW, -5n, 10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, -8n, 10n)).toBe(-1n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, -10n, 10n)).toBe(-1n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, -12n, 10n)).toBe(-1n)
+        expect(() => divide(ROUNDING_MODE.NEAREST_HALF_THROW, -15n, 10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, -18n, 10n)).toBe(-2n)
+      })
+
+      it('works on negatives', () => {
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, -18n, -10n)).toBe(2n)
+        expect(() => divide(ROUNDING_MODE.NEAREST_HALF_THROW, -15n, -10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, -12n, -10n)).toBe(1n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, -10n, -10n)).toBe(1n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, -8n, -10n)).toBe(1n)
+        expect(() => divide(ROUNDING_MODE.NEAREST_HALF_THROW, -5n, -10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, -2n, -10n)).toBe(0n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 0n, -10n)).toBe(0n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 2n, -10n)).toBe(0n)
+        expect(() => divide(ROUNDING_MODE.NEAREST_HALF_THROW, 5n, -10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 8n, -10n)).toBe(-1n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 10n, -10n)).toBe(-1n)
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 12n, -10n)).toBe(-1n)
+        expect(() => divide(ROUNDING_MODE.NEAREST_HALF_THROW, 15n, -10n)).toThrowError()
+        expect(divide(ROUNDING_MODE.NEAREST_HALF_THROW, 18n, -10n)).toBe(-2n)
+      })
+    })
+
     describe('half towards zero', () => {
       it('works', () => {
         expect(divide(ROUNDING_MODE.NEAREST_HALF_TOWARDS_ZERO, 18n, 10n)).toBe(2n)
@@ -443,8 +559,8 @@ describe('divide', () => {
         for (let i = 0; i < 1000; i++) {
           buckets[String(divide(ROUNDING_MODE.NEAREST_HALF_RANDOM, 15n, 10n))]++
         }
-        expect(450 < buckets[1] && buckets[1] < 550).toBe(true)
-        expect(450 < buckets[2] && buckets[2] < 550).toBe(true)
+        expect(buckets[1] > 450 && buckets[1] < 550).toBe(true)
+        expect(buckets[2] > 450 && buckets[2] < 550).toBe(true)
       })
     })
   })
@@ -457,8 +573,8 @@ describe('divide', () => {
         for (let i = 0; i < 1000; i++) {
           buckets[String(divide(ROUNDING_MODE.STOCHASTIC, -16n, -10n))]++
         }
-        expect(350 < buckets[1] && buckets[1] < 450).toBe(true)
-        expect(550 < buckets[2] && buckets[2] < 650).toBe(true)
+        expect(buckets[1] > 350 && buckets[1] < 450).toBe(true)
+        expect(buckets[2] > 550 && buckets[2] < 650).toBe(true)
       })
     })
   })


### PR DESCRIPTION
* Add a `.editorconfig` file.
* Start enforcing 100% code coverage in Jest and ignore the `coverage` test output directory.
* Add new rounding modes `THROW` which throws instead of attempting to round any result, and `NEAREST_HALF_THROW` which throws instead of attempting to round a result whose fraction was exactly .5.
* Start linting code. Hoorah for annoying ternary steps. Might fix this another day.